### PR TITLE
Downgrade stove so metadata.rb is uploaded

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rake'
-gem 'stove'
+gem 'stove', '= 3.2.2'
 gem 'berkshelf', '~> 3.1'
 gem 'chefspec', '~> 4.0'
 gem 'foodcritic', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,7 +197,7 @@ GEM
     solve (1.2.1)
       dep_selector (~> 1.0)
       semverse (~> 1.1)
-    stove (3.2.3)
+    stove (3.2.2)
       chef-api (~> 0.5)
       logify (~> 0.2)
     systemu (2.6.4)
@@ -229,5 +229,5 @@ DEPENDENCIES
   kitchen-vagrant
   rake
   rubocop (= 0.27.1)
-  stove
+  stove (= 3.2.2)
   test-kitchen (~> 1.0)


### PR DESCRIPTION
The latest version of [stove](https://github.com/sethvargo/stove) omits `metadata.rb` when uploading cookbooks. While it's a good idea, it was done without ensuring Chef's tools (particularly knife) worked with just `metadata.json`.
